### PR TITLE
added pandas to requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numba
 astropy
 Cython
 tqdm
+pandas


### PR DESCRIPTION
pandas wasn't in the install requirements, but is needed by your_h5plotter.py